### PR TITLE
Allow custom openai baseurl

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .vscode
 .env
 google.json
+.aider*

--- a/openai.go
+++ b/openai.go
@@ -24,6 +24,14 @@ func NewOpenAILLM(apiKey string) *OpenAILLM {
 	return &OpenAILLM{client: client}
 }
 
+// NewOpenAILLMWithBaseURL creates a new OpenAI LLM client with a custom base URL
+func NewOpenAILLMWithBaseURL(apiKey string, baseURL string) *OpenAILLM {
+	config := openai.DefaultConfig(apiKey)
+	config.BaseURL = baseURL
+	client := openai.NewClientWithConfig(config)
+	return &OpenAILLM{client: client}
+}
+
 func NewAzureLLM(apiKey string, azureOpenAIEndpoint string) *OpenAILLM {
 	// The latest API versions, including previews, can be found here:
 	// https://learn.microsoft.com/en-us/azure/ai-services/openai/reference#rest-api-versioning


### PR DESCRIPTION
**Describe the change** 
This PR introduces a new method `NewOpenAILLMWithBaseURL` that allows initializing the OpenAI LLM client  with a custom base URL. This change enables more flexibility in configuring the OpenAI client, particularly for users who need to connect to different OpenAI-compatible endpoints or proxy servers.

**Describe your solution** 
The solution adds a new constructor function `NewOpenAILLMWithBaseURL` that takes both an API key and a base URL as parameters. It uses OpenAI's configuration system to set up the client with a custom base URL while maintaining the existing functionality of the standard `NewOpenAILLM` constructor.